### PR TITLE
adding vhost into connection string

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,9 @@ function fastifyAmqp (fastify, opts, next) {
   const port = opts.port || 5672
   const user = opts.user || 'guest'
   const pass = opts.pass || 'guest'
+  const vhost = opts.vhost || ''
 
-  amqpClient.connect(`amqp://${user}:${pass}@${host}:${port}/`, function (err, connection) {
+  amqpClient.connect(`amqp://${user}:${pass}@${host}:${port}/${encodeURIComponent(vhost)}`, function (err, connection) {
     if (err) {
       next(err)
       return


### PR DESCRIPTION
Hi, 

I've have multiple clients that are bound on specific vhosts. So I need to specify that option.
I used `encodeURIComponent()` due to the fact that vhosts must be escaped.

Hope this can help (my requirements for sure :smile:),
Dario