### PR TITLE
Support url and socket options

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Rafael Gonzaga
+Copyright (c) 2021 Rafael Gonzaga
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ fastify.register(require('fastify-amqp'), {
 })
 
 fastify.get('/', function (request, reply) {
-  const channel = this.amqpChannel
+  const channel = this.amqp.channel
 
   const queue = 'hello'
   const msg = 'Hello world'

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ const fastify = require('fastify')()
 fastify.register(require('fastify-amqp'), {
   // the default value is amqp
   protocol: 'amqp',
-  host: 'localhost',
+  hostname: 'localhost',
   // the default value is 5672
   port: 5672,
   // the default value is guest
-  user: 'guest',
+  username: 'guest',
   // the default value is guest
-  pass: 'guest'
+  password: 'guest'
   // the default value is empty
   vhost: ''
 })
@@ -68,8 +68,8 @@ This plugin is just a wrapper to [amqplib](https://github.com/squaremo/amqp.node
 
 Contains:
 
-- amqpConn API to [here](http://www.squaremobius.net/amqp.node/channel_api.html#api_reference)
-- amqpChannel API to [here](http://www.squaremobius.net/amqp.node/channel_api.html#channel)
+- `amqp.connection` API to [here](http://www.squaremobius.net/amqp.node/channel_api.html#api_reference)
+- `amqp.channel` API to [here](http://www.squaremobius.net/amqp.node/channel_api.html#channel)
 
 ## Dependencies
 

--- a/examples/consumer/index.js
+++ b/examples/consumer/index.js
@@ -3,7 +3,7 @@ const Fastify = require('fastify')
 const app = Fastify()
 
 app.register(require('fastify-amqp'), {
-  host: 'localhost'
+  hostname: 'localhost'
 }).after(function (err) {
   if (err) throw err
 

--- a/examples/consumer/index.js
+++ b/examples/consumer/index.js
@@ -7,9 +7,9 @@ app.register(require('fastify-amqp'), {
 }).after(function (err) {
   if (err) throw err
 
-  if (!app.hasDecorator('amqpConn') || !app.hasDecorator('amqpChannel')) {
+  if (!app.hasDecorator('amqp')) {
     throw new Error('Undefined error with connection.')
   }
 
-  app.amqpChannel.assertQueue('')
+  app.amqp.channel.assertQueue('')
 })

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { Connection, Channel } from 'amqplib/callback_api';
-import { FastifyPluginCallback } from 'fastify';
+import { FastifyPluginAsync } from 'fastify';
 
 declare namespace fastifyAmqp {
   type FastifyAmqpConnObject = Connection
@@ -62,6 +62,6 @@ declare module 'fastify' {
   }
 }
 
-declare const fastifyAmqp: FastifyPluginCallback<fastifyAmqp.FastifyAmqpOptions>;
+declare const fastifyAmqp: FastifyPluginAsync<fastifyAmqp.FastifyAmqpOptions>;
 
 export default fastifyAmqp;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,16 +1,16 @@
-import { Connection, Channel } from 'amqplib/callback_api';
+import { Connection, Channel } from 'amqplib';
 import { FastifyPluginAsync } from 'fastify';
 
 declare namespace fastifyAmqp {
-  type FastifyAmqpConnObject = Connection
+  type FastifyAmqpConnObject = Connection;
 
-  type FastifyAmqpChannelObject = Channel
+  type FastifyAmqpChannelObject = Channel;
 
   interface FastifyAmqpOptions {
     /**
      * Full connection URL
      */
-    url?: string
+    url?: string;
     /**
      * Host of connection
      */
@@ -51,14 +51,16 @@ declare namespace fastifyAmqp {
     /**
      * Socket options
      */
-    socket?: any
+    socket?: any;
   }
 }
 
 declare module 'fastify' {
   interface FastifyInstance {
-    amqpConn: fastifyAmqp.FastifyAmqpConnObject;
-    amqpChannel: fastifyAmqp.FastifyAmqpChannelObject;
+    amqp: {
+      connection: fastifyAmqp.FastifyAmqpConnObject;
+      channel: fastifyAmqp.FastifyAmqpChannelObject;
+    }
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,16 +1,20 @@
 import { Connection, Channel } from 'amqplib/callback_api';
-import fastify, { FastifyPlugin } from 'fastify';
+import { FastifyPluginCallback } from 'fastify';
 
 declare namespace fastifyAmqp {
-  interface FastifyAmqpConnObject extends Connection {}
+  type FastifyAmqpConnObject = Connection
 
-  interface FastifyAmqpChannelObject extends Channel {}
+  type FastifyAmqpChannelObject = Channel
 
   interface FastifyAmqpOptions {
     /**
+     * Full connection URL
+     */
+    url?: string
+    /**
      * Host of connection
      */
-    host: string;
+    hostname?: string;
     /**
      * Port to connect
      * @default 5672
@@ -18,18 +22,36 @@ declare namespace fastifyAmqp {
     port?: number;
     /**
      * User to connect
-     * @default guest
+     * @default 'guest'
      */
-    user?: string;
+    username?: string;
     /**
      * Password to connect
-     * @default guest
+     * @default 'guest'
      */
-    pass?: string;
+    password?: string;
     /**
-     * Host to connect
+     * The desired locale for error messages
+     * @default 'en_US'
+     */
+    locale?: string;
+    /**
+     * @default 4kb
+     */
+    frameMax?: number;
+    /**
+     * The period of the connection heartbeat
+     * @default 0
+     */
+    heartbeat?: number;
+    /**
+     * @default '/'
      */
     vhost?: string;
+    /**
+     * Socket options
+     */
+    socket?: any
   }
 }
 
@@ -40,6 +62,6 @@ declare module 'fastify' {
   }
 }
 
-declare const fastifyAmqp: FastifyPlugin<fastifyAmqp.FastifyAmqpOptions>;
+declare const fastifyAmqp: FastifyPluginCallback<fastifyAmqp.FastifyAmqpOptions>;
 
 export default fastifyAmqp;

--- a/index.js
+++ b/index.js
@@ -3,20 +3,37 @@
 const fp = require('fastify-plugin')
 const amqpClient = require('amqplib/callback_api')
 
-function fastifyAmqp (fastify, opts, next) {
-  const host = opts.host
-
-  if (!host) {
-    next(new Error('`host` parameter is mandatory'))
-    return
+function getTarget ({
+  frameMax,
+  heartbeat,
+  hostname,
+  locale,
+  password,
+  port,
+  url,
+  username,
+  vhost
+}) {
+  if (url) {
+    return url
+  } else if (hostname) {
+    return {
+      frameMax,
+      heartbeat,
+      hostname,
+      locale,
+      password,
+      port,
+      username,
+      vhost
+    }
+  } else {
+    throw new Error('`url` parameter is mandatory if no hostname is provided')
   }
-  const protocol = opts.protocol || 'amqp'
-  const port = opts.port || 5672
-  const user = opts.user || 'guest'
-  const pass = opts.pass || 'guest'
-  const timeout = opts.timeout || 10000
+}
 
-  amqpClient.connect(`${protocol}://${user}:${pass}@${host}:${port}`, { timeout }, function (err, connection) {
+function fastifyAmqp (fastify, options, next) {
+  amqpClient.connect(getTarget(options), options.socket, function (err, connection) {
     if (err) {
       next(err)
       return

--- a/index.js
+++ b/index.js
@@ -35,10 +35,13 @@ function getTarget ({
 async function fastifyAmqp (fastify, options) {
   const connection = await amqpClient.connect(getTarget(options), options.socket)
   fastify.addHook('onClose', () => connection.close())
-  fastify.decorate('amqpConn', connection)
-
+  
   const channel = await connection.createChannel()
-  fastify.decorate('amqpChannel', channel)
+
+  fastify.decorate('amqp', {
+    connection,
+    channel
+  })
 }
 
 module.exports = fp(fastifyAmqp, {

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function getTarget ({
 async function fastifyAmqp (fastify, options) {
   const connection = await amqpClient.connect(getTarget(options), options.socket)
   fastify.addHook('onClose', () => connection.close())
-  
+
   const channel = await connection.createChannel()
 
   fastify.decorate('amqp', {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -4,6 +4,6 @@ import fastifyAmqp from '../fastify-amqp';
 const app = fastify();
 
 app.register(fastifyAmqp, { hostname: 'localhost' }).after((_err) => {
-  const amqp = app.amqpConn;
-  const amqpChannel = app.amqpChannel;
+  const amqp = app.amqp.connection;
+  const amqpChannel = app.amqp.channel;
 })

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -3,7 +3,7 @@ import fastifyAmqp from '../fastify-amqp';
 
 const app = fastify();
 
-app.register(fastifyAmqp, { host: 'localhost' }).after((_err) => {
+app.register(fastifyAmqp, { hostname: 'localhost' }).after((_err) => {
   const amqp = app.amqpConn;
   const amqpChannel = app.amqpChannel;
 })

--- a/package.json
+++ b/package.json
@@ -32,13 +32,13 @@
     "fastify-plugin": "^3.0.0"
   },
   "devDependencies": {
-    "@types/amqplib": "^0.5.13",
-    "fastify": "^3.3.0",
+    "@types/amqplib": "^0.5.17",
+    "fastify": "^3.10.1",
     "pre-commit": "^1.2.2",
-    "standard": "^16.0.0",
-    "tap": "^14.2.5",
+    "standard": "^16.0.3",
+    "tap": "^14.11.0",
     "tsd": "^0.14.0",
-    "typescript": "^4.0.2"
+    "typescript": "^4.1.3"
   },
   "pre-commit": [
     "lint",

--- a/test.js
+++ b/test.js
@@ -16,8 +16,7 @@ test('undefined connection', t => {
     t.equal(typeof err, typeof {})
     t.assert(err instanceof Error)
 
-    t.notOk(app.amqpConn, 'Should not has amqpConn')
-    t.notOk(app.amqpChannel, 'Should not has amqpChannel')
+    t.notOk(app.amqp, 'Should not have amqp decorator')
   })
 })
 
@@ -31,8 +30,7 @@ test('invalid connection', t => {
     t.equal(typeof err, typeof {})
     t.assert(err instanceof Error)
 
-    t.notOk(app.amqpConn, 'Should not has amqpConn')
-    t.notOk(app.amqpChannel, 'Should not has amqpChannel')
+    t.notOk(app.amqp, 'Should not have amqp decorator')
   })
 })
 
@@ -44,8 +42,8 @@ test('connection ok without send port', t => {
     hostname: HOST_OK
   }).ready(err => {
     t.error(err)
-    t.ok(app.amqpConn)
-    t.ok(app.amqpChannel)
+    t.ok(app.amqp.connection)
+    t.ok(app.amqp.channel)
   })
 })
 
@@ -58,8 +56,8 @@ test('connection ok', t => {
     port: PORT_OK
   }).ready(err => {
     t.error(err)
-    t.ok(app.amqpConn)
-    t.ok(app.amqpChannel)
+    t.ok(app.amqp.connection)
+    t.ok(app.amqp.channel)
   })
 })
 
@@ -72,8 +70,8 @@ test('connection with protocol ok', t => {
     protocol: PROTOCOL_OK
   }).ready(err => {
     t.error(err)
-    t.ok(app.amqpConn)
-    t.ok(app.amqpChannel)
+    t.ok(app.amqp.connection)
+    t.ok(app.amqp.channel)
   })
 })
 

--- a/test.js
+++ b/test.js
@@ -26,7 +26,7 @@ test('invalid connection', t => {
   const app = build(t)
 
   app.register(fastifyAmqp, {
-    host: HOST_INVALID
+    hostname: HOST_INVALID
   }).ready(err => {
     t.equal(typeof err, typeof {})
     t.assert(err instanceof Error)
@@ -41,7 +41,7 @@ test('connection ok without send port', t => {
   const app = build(t)
 
   app.register(fastifyAmqp, {
-    host: HOST_OK
+    hostname: HOST_OK
   }).ready(err => {
     t.error(err)
     t.ok(app.amqpConn)
@@ -54,7 +54,7 @@ test('connection ok', t => {
   const app = build(t)
 
   app.register(fastifyAmqp, {
-    host: HOST_OK,
+    hostname: HOST_OK,
     port: PORT_OK
   }).ready(err => {
     t.error(err)
@@ -68,7 +68,7 @@ test('connection with protocol ok', t => {
   const app = build(t)
 
   app.register(fastifyAmqp, {
-    host: HOST_OK,
+    hostname: HOST_OK,
     protocol: PROTOCOL_OK
   }).ready(err => {
     t.error(err)

--- a/test.js
+++ b/test.js
@@ -9,7 +9,7 @@ const HOST_INVALID = '1234'
 const PROTOCOL_OK = 'amqp'
 
 test('undefined connection', t => {
-  t.plan(4)
+  t.plan(3)
   const app = build(t)
 
   app.register(fastifyAmqp, {}).ready(err => {
@@ -21,11 +21,14 @@ test('undefined connection', t => {
 })
 
 test('invalid connection', t => {
-  t.plan(4)
+  t.plan(3)
   const app = build(t)
 
   app.register(fastifyAmqp, {
-    hostname: HOST_INVALID
+    hostname: HOST_INVALID,
+    socket: {
+      timeout: 10000
+    }
   }).ready(err => {
     t.equal(typeof err, typeof {})
     t.assert(err instanceof Error)
@@ -47,13 +50,26 @@ test('connection ok without send port', t => {
   })
 })
 
-test('connection ok', t => {
+test('connection object', t => {
   t.plan(3)
   const app = build(t)
 
   app.register(fastifyAmqp, {
     hostname: HOST_OK,
     port: PORT_OK
+  }).ready(err => {
+    t.error(err)
+    t.ok(app.amqp.connection)
+    t.ok(app.amqp.channel)
+  })
+})
+
+test('connection url', t => {
+  t.plan(3)
+  const app = build(t)
+
+  app.register(fastifyAmqp, {
+    url: `${PROTOCOL_OK}://${HOST_OK}:${PORT_OK}`
   }).ready(err => {
     t.error(err)
     t.ok(app.amqp.connection)


### PR DESCRIPTION
## Main changes

- Rename options to match original [amqplib options](http://www.squaremobius.net/amqp.node/channel_api.html#connect) (more natural for newcomers)
- Support for `url` option (useful when reading from `process.env`)
- Support socket options
- Use `async/await` syntax (simpler code)
- Use single `amqp` decorator (easy to extend in future, just add another property)